### PR TITLE
Correção no teste

### DIFF
--- a/docs/unittest_mock.md
+++ b/docs/unittest_mock.md
@@ -73,7 +73,7 @@ class TestExecuteOK(TestCase):
             self.result = app.execute()
   [...]
     def test_gets_csvfile_from_urllink_in_config(self):
-        self.mock_urlopen.assert_called_once_with(config.INCENDIOS_CSV_FILE_LINK)
+        self.mock_urlopen.assert_called_with(config.INCENDIOS_CSV_FILE_LINK)
 
 [...]
 ```


### PR DESCRIPTION
O teste `test_gets_csvfile_from_urllink_in_config` está com `assert_called_once_with`, contudo com as definições dos mocks no `setupClass` e no `tearDownClass` onde ambos executam apenas uma vez para classe toda, o método execute será chamado mais de uma vez e consequentemente o `urlopen`.